### PR TITLE
Add web UI to manually trigger synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Zawiera:
 - **mock serwery** (FastAPI) symulujące API fireTMS i Optimy do bezpiecznych testów
 - Dockerfile + docker-compose oraz unit pliki systemd
 - testowe dane
+- prosty interfejs webowy (`web.py`) z przyciskiem do ręcznego uruchomienia synchronizacji
 
 > **Uwaga:** Endpointy i modele w mockach są zgodne z przykładową strukturą z `mapper.py`. W produkcji podmień URL-e i ewentualnie dostosuj mapowanie.
 
@@ -26,7 +27,7 @@ Zawiera:
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn tests.mock_server:app --reload --port 8000  # w innym terminalu (mocki)
+uvicorn tests.mock_server:app --reload --host 0.0.0.0 --port 8000  # w innym terminalu (mocki)
 ```
 
 4. Uruchom synchronizację:
@@ -45,8 +46,9 @@ Powinieneś zobaczyć logi „pobrano 25 faktur” i „wysłano do Optimy…”
 docker compose up --build
 ```
 
-- `mock` uruchamia FastAPI pod `http://localhost:8000`
+- `mock` udostępnia testowe API na porcie `8000`
 - `sync` startuje kontener z integracją według `.env`
+- `web` udostępnia prosty interfejs na porcie `8080`
 
 ---
 
@@ -97,12 +99,25 @@ LOG_DIR=logs
 
 ---
 
+## Webowy interfejs
+
+Prosty panel WWW z przyciskiem do ręcznego uruchomienia synchronizacji:
+
+```bash
+uvicorn web:app --reload --host 0.0.0.0 --port 8080
+```
+
+Po starcie odwiedź `http://<host>:8080` (np. adres serwera) i kliknij **Run sync**.
+
+---
+
 ## Struktura projektu
 
 ```
 .
 ├── README.md
 ├── sync.py
+├── web.py
 ├── mapper.py
 ├── models.py
 ├── config.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,12 @@ services:
     volumes:
       - ./:/app
     command: python sync.py
+  web:
+    build: .
+    environment:
+      - PYTHONUNBUFFERED=1
+    volumes:
+      - ./:/app
+    ports:
+      - "8080:8080"
+    command: uvicorn web:app --host 0.0.0.0 --port 8080

--- a/web.py
+++ b/web.py
@@ -1,0 +1,37 @@
+import asyncio
+import os
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+import uvicorn
+
+from sync import run_sync
+
+app = FastAPI()
+
+@app.get('/', response_class=HTMLResponse)
+async def index():
+    return """
+    <html>
+        <head>
+            <title>fireTMS ↔ Optima Sync</title>
+        </head>
+        <body>
+            <h1>fireTMS ↔ Optima Sync</h1>
+            <button onclick=\"fetch('/run-sync',{method:'POST'}).then(r=>r.json()).then(d=>alert(d.status))\">Run sync</button>
+        </body>
+    </html>
+    """
+
+@app.post('/run-sync')
+async def trigger_sync():
+    asyncio.create_task(run_sync())
+    return {"status": "started"}
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8080")),
+    )


### PR DESCRIPTION
## Summary
- add FastAPI web app with a button that triggers `run_sync`
- document the new interface and include it in docker-compose
- expose the web UI on all interfaces, not just localhost

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee683e27c8321b58936e25b18d354